### PR TITLE
Setting form limits for total user count and duration.

### DIFF
--- a/UI/master-script-form/src/app/common/Validators/ConfigFormValidators.ts
+++ b/UI/master-script-form/src/app/common/Validators/ConfigFormValidators.ts
@@ -2,11 +2,9 @@ import { AbstractControl, ValidationErrors } from '@angular/forms';
 
 export class ConfigFormValidators {
 
-    static limitedNumber(control: AbstractControl) : ValidationErrors | null {
-        if(isNaN(control.value)) {
-            return {isNumber: false};
-        }  else if(control.value <= 0) {
-            return {isMoreThanZero: false};
+    static hasNumberLimit(control: AbstractControl) : ValidationErrors | null {
+        if(control.value > 4000) {
+            return {exceedsNumberLimit: true};
         }
 
         return null;

--- a/UI/master-script-form/src/app/config-form/config-form.component.html
+++ b/UI/master-script-form/src/app/config-form/config-form.component.html
@@ -3,18 +3,20 @@
 <form [formGroup]="configForm" (ngSubmit)="onSubmit()" name="configForm">
     <div class="form-group">
         <label>Total Users</label>
-        <input type="text" class="form-control" formControlName="total_users" placeholder="Ex: 25">
-        <small id="totalUsersHelp" class="form-text text-muted">Total number of users in the test</small>
+        <input type="text" class="form-control" formControlName="total_users" placeholder="Default: 25">
+        <small id="totalUsersHelp" class="form-text text-muted">Total number of users in the test (minimum 1 user, maximum 4000 users)</small>
         <div *ngIf="total_users.touched && total_users.invalid">
             <div class="alert alert-danger" *ngIf="total_users.errors.pattern">Please provide only number values.</div>
             <div class="alert alert-danger" *ngIf="total_users.errors.cannotContainSpaces">Field cannot contain spaces.
+            </div>
+            <div class="alert alert-danger" *ngIf="total_users.errors.exceedsNumberLimit">Value cannot exceed 4000.
             </div>
         </div>
     </div>
 
     <div class="form-group">
         <label>Ramp Up Time</label>
-        <input type="text" class="form-control" formControlName="ramp_up_time" placeholder="Ex: 300">
+        <input type="text" class="form-control" formControlName="ramp_up_time" placeholder="Default: 300">
         <small class="form-text text-muted">Ramp up time in seconds</small>
         <div *ngIf="ramp_up_time.touched && ramp_up_time.invalid">
             <div class="alert alert-danger" *ngIf="ramp_up_time.errors.pattern">Please provide only number values.</div>
@@ -26,8 +28,8 @@
 
     <div class="form-group">
         <label>Duration</label>
-        <input type="text" class="form-control" formControlName="duration" placeholder="Ex: 900">
-        <small class="form-text text-muted">Duration of test in seconds</small>
+        <input type="text" class="form-control" formControlName="duration" placeholder="Default: 900">
+        <small class="form-text text-muted">Duration of test in seconds (minimum 60 seconds)</small>
         <div *ngIf="duration.touched && duration.invalid">
             <div class="alert alert-danger" *ngIf="duration.errors.pattern">Please provide only number values.</div>
             <div class="alert alert-danger" *ngIf="duration.errors.cannotContainSpaces">Field cannot contain spaces.

--- a/UI/master-script-form/src/app/config-form/config-form.component.ts
+++ b/UI/master-script-form/src/app/config-form/config-form.component.ts
@@ -59,7 +59,7 @@ export class ConfigFormComponent implements OnInit {
 
   initializeForm(): void {
     this.configForm = this.fb.group({
-      total_users: new FormControl('', [Validators.pattern(/^(?=.*\d)[\d ]+$/), ConfigFormValidators.cannotContainSpaces]),
+      total_users: new FormControl('', [Validators.pattern(/^(?=.*\d)[\d ]+$/), ConfigFormValidators.cannotContainSpaces, ConfigFormValidators.hasNumberLimit]),
       duration: new FormControl('', [Validators.pattern(/^(?=.*\d)[\d ]+$/), ConfigFormValidators.cannotContainSpaces]),
       ramp_up_time: new FormControl('', [Validators.pattern(/^(?=.*\d)[\d ]+$/), ConfigFormValidators.cannotContainSpaces]),
       load_type: this.loadTypes[0],
@@ -144,6 +144,8 @@ export class ConfigFormComponent implements OnInit {
     this.resetForm();
   }
 
+  
+
   storeTestAsCookie(dashboardUrl) {
     let currentTime = new Date();
     let expireTime = new Date(currentTime.getTime() + this.duration.value * 1000 + this.ramp_up_time.value * 1000);
@@ -171,6 +173,7 @@ export class ConfigFormComponent implements OnInit {
   }
 
   onSubmit(): void {
+    this.setFormDefaults();
     this.hideSubmitMessages = false;
     if (this.configForm.valid) {
       //append the necessary data to formData and send to Flask server
@@ -182,6 +185,28 @@ export class ConfigFormComponent implements OnInit {
       formData.append('form', JSON.stringify(this.configForm.getRawValue()));
       this.postFormToServer(formData);
       this.submitted = true;
+    }
+  }
+
+  setFormDefaults() {
+    //if user enters less that 1 total_users, default to 1. Otherwise if no input, default to 25.
+    if(this.total_users.value === '') {
+      this.total_users.setValue('25');
+    } else if (this.total_users.value < 1) {
+      this.total_users.setValue('1');
+    } 
+
+    //if user enters no ramp up time, default is 300.
+    if(this.ramp_up_time.value === '') {
+      this.ramp_up_time.setValue('300');
+    }
+
+    //if user enters no duration, default is 900. If they enter a less than 60 second duration, default to 60.
+    if(this.duration.value === '') {
+      this.duration.setValue('900');
+    }
+    else if (this.duration.value < 60) {
+      this.duration.setValue('60');
     }
   }
 


### PR DESCRIPTION
- Min users is 1, max is 4000. UI complains if value above 4000 is entered, will default to 1 if 0 is entered. If no value entered, default in back end is 25.
- Duration: Min is 60, if user enters below 60, it will default to 60. If no value entered, default in back end is 900, and front end will use that same value.