### PR TITLE
Ali UI adding help link and reset button

### DIFF
--- a/UI/master-script-form/src/app/config-form/config-form.component.html
+++ b/UI/master-script-form/src/app/config-form/config-form.component.html
@@ -1,5 +1,7 @@
 <h1><img src="assets/gwl.png"> ICAP Performance Testing </h1>
 
+<a href="https://github.com/k8-proxy/aws-jmeter-test-engine/blob/master/jmeter-icap/instructions/How-to-Generate-Load-with-OVA.md" target="_blank" style="float: right;">Instructions on How to Generate Load</a>
+
 <form [formGroup]="configForm" (ngSubmit)="onSubmit()" name="configForm">
     <div class="form-group">
         <label>Total Users</label>
@@ -97,6 +99,10 @@
         [popoverTitle]="popoverTitle" [popoverMessage]="popoverMessage" placement="right" (confirm)="onStopTests()"
         type="button">
         Stop Load
+    </button>
+
+    <button id="reset-form" [disabled]="configForm.pristine" class="btn btn-warning" type="button" (click)="resetForm()">
+        Clear Form
     </button>
 
 

--- a/UI/master-script-form/src/app/config-form/config-form.component.ts
+++ b/UI/master-script-form/src/app/config-form/config-form.component.ts
@@ -141,7 +141,6 @@ export class ConfigFormComponent implements OnInit {
     this.responseUrl = response.toString();
     this.responseReceived = true;
     this.storeTestAsCookie(this.responseUrl);
-    this.resetForm();
   }
 
   
@@ -154,14 +153,10 @@ export class ConfigFormComponent implements OnInit {
   }
 
   resetForm() {
-    var oldLoadType = this.configForm.get('load_type').value;
-    var oldTls = this.configForm.get('enable_tls').value;
-    var oldTlsIgnoreError = this.configForm.get('tls_ignore_error').value;
     this.configForm.reset();
-    this.configForm.get('load_type').setValue(oldLoadType);
-    this.configForm.get('enable_tls').setValue(oldTls);
-    this.configForm.get('tls_ignore_error').setValue(oldTlsIgnoreError);
-    this.hideSubmitMessages = false;
+    this.initializeForm();
+    this.onLoadTypeChange();
+    this.hideSubmitMessages = true;
   }
 
   postFormToServer(formData: FormData) {


### PR DESCRIPTION
- Link to instructions on upper right hand corner of form added
- Reset form button: Form no longer resets upon submitting a test. When the reset form button is pressed, all fields are cleared and the form is reset to its original state. The button is also greyed out if the form has not been touched.