### PR TITLE
Ali fixing bugs: Issues with ramp up time calculation, test names displayed on list.

### DIFF
--- a/UI Scaled Solution/master-script-form/package-lock.json
+++ b/UI Scaled Solution/master-script-form/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/UI/master-script-form/src/app/config-form/config-form.component.html
+++ b/UI/master-script-form/src/app/config-form/config-form.component.html
@@ -81,7 +81,7 @@
 
     <div class="form-group">
         <label>Prefix:</label>
-        <input type="text" class="form-control" formControlName="prefix" placeholder="Ex: example-prefix">
+        <input type="text" class="form-control" formControlName="prefix" placeholder="default: demo">
         <small class="form-text text-muted">Prefix must not contain spaces</small>
         <div *ngIf="prefix.touched && prefix.invalid">
             <div class="alert alert-danger" *ngIf="prefix.errors.cannotContainSpaces">Field cannot contain spaces.</div>

--- a/UI/master-script-form/src/app/config-form/config-form.component.ts
+++ b/UI/master-script-form/src/app/config-form/config-form.component.ts
@@ -204,6 +204,10 @@ export class ConfigFormComponent implements OnInit {
     else if (this.duration.value < 60) {
       this.duration.setValue('60');
     }
+
+    if(this.prefix.value === '') {
+      this.prefix.setValue('demo');
+    }
   }
 
   onStopTests() {

--- a/UI/master-script-form/src/app/config-form/config-form.component.ts
+++ b/UI/master-script-form/src/app/config-form/config-form.component.ts
@@ -147,8 +147,9 @@ export class ConfigFormComponent implements OnInit {
 
   storeTestAsCookie(dashboardUrl) {
     let currentTime = new Date();
-    let expireTime = new Date(currentTime.getTime() + this.duration.value * 1000 + this.ramp_up_time.value * 1000);
-    let key = this.prefix.value === null ? "ICAP Live Performance Dashboard" : this.prefix.value + " ICAP Live Performance Dashboard";
+    let expireTime = new Date(currentTime.getTime() + this.duration.value * 1000);
+    let testTitle = this.IcapOrProxy === this.urlChoices[0] ? "ICAP Live Performance Dashboard" : "Proxy Site Live Performance Dashboard";
+    let key = this.prefix.value === null ? testTitle : this.prefix.value + " " + testTitle;
     this.cookieService.set(key, dashboardUrl, expireTime);
   }
 


### PR DESCRIPTION
- Ramp up time is no longer included in overall test duration when displaying test in list.
- Tests shown in currently running tests list are now named according to whether the test is ICAP or Proxy:
- --- prefix + "ICAP Live Performance Dashboard"
- --- prefix + "Proxy Site Live Performance Dashboard"
- Default prefix is now "demo" in cases where no prefix is input.