### PR TITLE
Fixed issue where tests were inserted into database even if they were deleted, other minor issues addressed

### DIFF
--- a/UI Scaled Solution/master-script-form/src/app/common/app settings/AppSettings.ts
+++ b/UI Scaled Solution/master-script-form/src/app/common/app settings/AppSettings.ts
@@ -6,4 +6,5 @@ export class AppSettings {
     public static cookiesExist: boolean;
     public static testPrefixSet = new Set<string>();
     public static addingPrefix: boolean = false;
+    public static serverIp: string = "http://127.0.0.1:5000/"
 }

--- a/UI Scaled Solution/master-script-form/src/app/common/services/shared.service.ts
+++ b/UI Scaled Solution/master-script-form/src/app/common/services/shared.service.ts
@@ -76,7 +76,7 @@ export class SharedService {
 
     buildResultsDataRow(dataRow, columnArray): ResultsRowElement {
         let _testName = this.buildTestName(dataRow[this.getDataItemIndex('Prefix', columnArray)], dataRow[this.getDataItemIndex('LoadType', columnArray)]);
-        let _startTime = new Date(dataRow[this.getDataItemIndex('StartTime', columnArray)]);
+        let _startTime = new Date(dataRow[this.getDataItemIndex('time', columnArray)]);
         let _runId = dataRow[this.getDataItemIndex('RunId', columnArray)];
         let _duration = dataRow[this.getDataItemIndex('Duration', columnArray)];
         let _rampUp = dataRow[this.getDataItemIndex('RampUp', columnArray)];
@@ -87,6 +87,7 @@ export class SharedService {
         let _averageResponseTime = dataRow[this.getDataItemIndex('AverageResponseTime', columnArray)];
         let _maxConcurrentPods = dataRow[this.getDataItemIndex('TotalUsers', columnArray)];
         let grafanaUid = dataRow[this.getDataItemIndex('GrafanaUid', columnArray)];
+        _startTime = new Date(_startTime.getTime() - (parseFloat(_duration) * 1000))
         let _dashboardUrl = this.buildGrafanaLink(dataRow[this.getDataItemIndex('Prefix', columnArray)], dataRow[this.getDataItemIndex('LoadType', columnArray)], _startTime, _duration, grafanaUid);
         let _status = dataRow[this.getDataItemIndex('Status', columnArray)]
         let row: ResultsRowElement = {

--- a/UI Scaled Solution/master-script-form/src/app/common/services/shared.service.ts
+++ b/UI Scaled Solution/master-script-form/src/app/common/services/shared.service.ts
@@ -1,7 +1,7 @@
 /*
     This service is responsible for querying the database and storing retrieved data for use in other componenets
 */
-
+import { AppSettings } from './../app settings/AppSettings';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
@@ -62,7 +62,7 @@ export class SharedService {
     }
 
     getTestsFromDatabase() {
-        this.http.get('http://127.0.0.1:5000/').subscribe(response => this.processRetrievedTestData(response), (err) => { this.onError(err) });
+        this.http.get(AppSettings.serverIp).subscribe(response => this.processRetrievedTestData(response), (err) => { this.onError(err) });
     }
 
     processRetrievedTestData(response) {

--- a/UI Scaled Solution/master-script-form/src/app/config-form/config-form.component.ts
+++ b/UI Scaled Solution/master-script-form/src/app/config-form/config-form.component.ts
@@ -156,11 +156,11 @@ export class ConfigFormComponent implements OnInit {
   }
 
   postFormToServer(formData: FormData) {
-    this.http.post('http://127.0.0.1:5000/', formData).subscribe(response => this.processResponse(response, formData), (err) => { this.onError(err) });
+    this.http.post(AppSettings.serverIp, formData).subscribe(response => this.processResponse(response, formData), (err) => { this.onError(err) });
   }
 
   postStopRequestToServer(formData: FormData) {
-    this.http.post('http://127.0.0.1:5000/', formData).toPromise();
+    this.http.post(AppSettings.serverIp, formData).toPromise();
   }
 
   onSubmit(): void {

--- a/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.html
+++ b/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.html
@@ -35,13 +35,13 @@
 
         <ng-container matColumnDef="averageResponseTime">
             <th *matHeaderCellDef> Average Response Time </th>
-            <td *matCellDef="let element"> {{element.averageResponseTime}} Seconds </td>
+            <td *matCellDef="let element"> {{element.averageResponseTime | number : '1.2-2'}} ms </td>
         </ng-container>
 
-        <ng-container matColumnDef="maxConcurrentPods">
+        <!-- <ng-container matColumnDef="maxConcurrentPods">
             <th *matHeaderCellDef> Max Concurrent Pods </th>
             <td *matCellDef="let element"> {{element.maxConcurrentPods}} </td>
-        </ng-container>
+        </ng-container> -->
 
         <ng-container matColumnDef="status">
             <th *matHeaderCellDef> Status </th>

--- a/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.html
+++ b/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.html
@@ -43,13 +43,13 @@
             <td *matCellDef="let element"> {{element.maxConcurrentPods}} </td>
         </ng-container> -->
 
-        <ng-container matColumnDef="status">
+        <!-- <ng-container matColumnDef="status">
             <th *matHeaderCellDef> Status </th>
             <td *matCellDef="let element">
                 <img *ngIf="element.status == 0" src="assets/red.png">
                 <img *ngIf="element.status == 1" src="assets/green.png">
             </td>
-        </ng-container>
+        </ng-container> -->
 
         <!-- Header row title -->
         <ng-container matColumnDef="header-row-title">

--- a/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.ts
+++ b/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.ts
@@ -19,7 +19,7 @@ export class ResultsTableComponent implements OnInit {
 
 
   dataSource: ResultsRowElement[] = [];
-  displayedColumns: string[] = ['testName', 'startTime', 'duration', 'totalRequests', 'successfulRequests', 'failedRequests', 'averageResponseTime', 'maxConcurrentPods', 'status']; //add and remove columns here before adding/remove in html
+  displayedColumns: string[] = ['testName', 'startTime', 'duration', 'totalRequests', 'successfulRequests', 'failedRequests', 'averageResponseTime', 'status']; //add and remove columns here before adding/remove in html
   testsExist: boolean;
 
   constructor(private sharedService: SharedService) {

--- a/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.ts
+++ b/UI Scaled Solution/master-script-form/src/app/results-table/results-table.component.ts
@@ -19,7 +19,7 @@ export class ResultsTableComponent implements OnInit {
 
 
   dataSource: ResultsRowElement[] = [];
-  displayedColumns: string[] = ['testName', 'startTime', 'duration', 'totalRequests', 'successfulRequests', 'failedRequests', 'averageResponseTime', 'status']; //add and remove columns here before adding/remove in html
+  displayedColumns: string[] = ['testName', 'startTime', 'duration', 'totalRequests', 'successfulRequests', 'failedRequests', 'averageResponseTime']; //add and remove columns here before adding/remove in html
   testsExist: boolean;
 
   constructor(private sharedService: SharedService) {

--- a/UI Scaled Solution/master-script-form/src/app/tests-table/tests-table.component.ts
+++ b/UI Scaled Solution/master-script-form/src/app/tests-table/tests-table.component.ts
@@ -114,7 +114,7 @@ export class TestsTableComponent implements OnInit {
     const formData = new FormData();
     formData.append("button", "stop_individual_test");
     formData.append("stack", stackName);
-    this.http.post('http://127.0.0.1:5000/', formData).toPromise();
+    this.http.post(AppSettings.serverIp, formData).toPromise();
   }
 
   updateCookiesExistAndPrefixSet() {

--- a/jmeter-icap/scripts/metrics.py
+++ b/jmeter-icap/scripts/metrics.py
@@ -86,7 +86,7 @@ class InfluxDBMetrics():
     @staticmethod
     def count_query(prefix, start, finish, condition):
         try:
-            str_query = 'SELECT COUNT("avg") FROM '\
+            str_query = 'SELECT SUM("count") FROM '\
                     + prefix + '_jmetericap WHERE '\
                     + ' time >= \'' + start + '\' AND ' \
                     + ' time <= \'' + finish + '\' AND '\

--- a/jmeter-icap/scripts/metrics.py
+++ b/jmeter-icap/scripts/metrics.py
@@ -86,7 +86,7 @@ class InfluxDBMetrics():
     @staticmethod
     def count_query(prefix, start, finish, condition):
         try:
-            str_query = 'SELECT SUM("count") FROM '\
+            str_query = 'SELECT COUNT("avg") FROM '\
                     + prefix + '_jmetericap WHERE '\
                     + ' time >= \'' + start + '\' AND ' \
                     + ' time <= \'' + finish + '\' AND '\

--- a/jmeter-icap/scripts/metrics.py
+++ b/jmeter-icap/scripts/metrics.py
@@ -131,7 +131,7 @@ class InfluxDBMetrics():
                 mean = item['mean']
                 if mean:
                     return float(mean)
-            return 0
+            return float(0)
         except Exception as e:
             print("ERROR: metrics.mean_query: {}".format(e))
             exit(1)


### PR DESCRIPTION
- create_stack_dash: If user stops a test from UI, it will no longer be added to database after duration is complete
- metrics.py: Average response time always returns a float value, preventing type mismatch errors when the value is 0 (integer) and we try to insert it into influxdb
- UI changes: 
- Removed "Max Concurrent Pods" column from test results display. 
- Removed "Status" column from test results display. 
- Average response time is now displayed in ms, not seconds. It is also correct to two decimal places.
- Fixed issue where Grafana link's time window was off
