### PR TITLE
Adding Setup UI warning for upload failure, fixing minor issues.

### DIFF
--- a/UI Scaled Solution/master-script-form/src/app/common/app settings/AppSettings.ts
+++ b/UI Scaled Solution/master-script-form/src/app/common/app settings/AppSettings.ts
@@ -3,7 +3,7 @@ export class AppSettings {
     public static regions: string[] = ['eu-west-1', 'eu-east-1', 'us-west-1', 'eu-west-2'];
     public static loadTypeNames: string[] = ['Direct', 'Proxy SharePoint', 'Direct Sharepoint'];
     public static endPointFieldTitles: string[] = ["ICAP Server Endpoint URL*", "SharePoint Endpoint URL*", "SharePoint Endpoint URL*", "Proxy IP Address*"];
-    public static endPointFieldPlaceholders: string[] = ["Required", "Ex: saas1.sharepoint.com", "Required"]
+    public static endPointFieldPlaceholders: string[] = ["Ex: icap-client.region.app.provider.com", "Ex: saas1.sharepoint.com", "Ex: saas1.sharepoint.com"]
     public static testNames: string[] = ["ICAP Live Performance Dashboard", "SharePoint Proxy Live Performance Dashboard", "SharePoint Direct Live Performance Dashboard", "Proxy Site Live Performance Dashboard"];
     public static dashboardNames: string[] = ["-icap-live-performance-dashboard", "-demo-dashboard-sharepoint", "-sharepoint-direct-live-performance-dashboard", "-proxysite-live-performance-dashboard"];
     public static cookiesExist: boolean;

--- a/jmeter-icap/scripts/flask_server_scaled.py
+++ b/jmeter-icap/scripts/flask_server_scaled.py
@@ -37,8 +37,11 @@ def parse_request():
         elif button_pressed == 'setup_config':
             data = json.loads(request.form.get('form'))
             print('Setup Data sent from UI: {0}'.format(data))
-            update_config_env(data)
-            return make_response(jsonify(response="OK"), 200)
+            result = update_config_env(data)
+            if result == 0:
+                return make_response(jsonify(response="OK"), 200)
+            else:
+                return make_response(jsonify(response="UPLOADFAILED"), 200)
 
     if request.method == 'GET':
         if request.args['request_type'] == 'test_results':

--- a/jmeter-icap/scripts/ui_setup.py
+++ b/jmeter-icap/scripts/ui_setup.py
@@ -7,7 +7,7 @@ CONFIG_ENV_PATH = './config.env'
 
 
 def update_config_env(setup_json):
-
+    result = 0
     found = dotenv.find_dotenv(CONFIG_ENV_PATH)
     if not found:
         print("Please create config.env file similar to config.env.sample")
@@ -30,7 +30,8 @@ def update_config_env(setup_json):
             Config.client_secret = setup_json['client_secret']
 
     if setup_json['upload_test_data']:
-        upload_test_data_to_s3(Config)
+        result = upload_test_data_to_s3(Config)
+    return result
 
 
 def retrieve_config_fields():
@@ -61,5 +62,10 @@ def adjust_eof_newline():
 def upload_test_data_to_s3(config):
     root_dir = '/opt/data/'
     bucket_path = "s3://{}".format(config.test_data_bucket)
+    output = 1
+    try:
+        output = subprocess.call(['aws', 's3', 'sync', root_dir, bucket_path])
+    except Exception as e:
+        print("Error uploading to S3: {}".format(e))
 
-    subprocess.call(['aws', 's3', 'sync', root_dir, bucket_path])
+    return output

--- a/jmeter-icap/scripts/ui_tasks.py
+++ b/jmeter-icap/scripts/ui_tasks.py
@@ -102,7 +102,7 @@ def determine_tls_and_port_params(config, input_enable_tls, input_tls_ignore_ver
 
         # If TLS is enabled, get the user preference as to whether or not TLS verification should be used
         if input_enable_tls:
-            config.tls_verification_method = "tls-no-verify" if input_tls_ignore_verification else ""
+            config.tls_verification_method = "-tls-no-verify" if input_tls_ignore_verification else ""
 
 
 class LoadType(str, Enum):


### PR DESCRIPTION
UI:
- Added example value for endpoints
- Setup UI: Added functionality where if S3 upload fails, but config update succeeds, a warning message is output to the user informing them of this
Python back end:
- tls-no-verify needed to include a hyphen at the start of tag