### PR TITLE
Modifying CloudFormation template to automate secret creation in Step 4 of current instructions

### DIFF
--- a/jmeter-icap/cloudformation/AWS-Performance-Dashboard-and-S3-Bucket.yaml
+++ b/jmeter-icap/cloudformation/AWS-Performance-Dashboard-and-S3-Bucket.yaml
@@ -271,6 +271,16 @@ Resources:
     Type: AWS::IAM::AccessKey
     Properties:
       UserName: !Ref 'S3User'
+  SecretsManagerAccessKeys:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Description: "Secret containing Load Generator IAM user access credentials"
+      Name: "LoadGeneratorIamUserCredentials"
+      SecretString:
+        !Sub
+        - '{"AWS_Access_Key":"${AccessKey}","AWS_Secret_Key ":"${SecretAccessKey}"}'
+        - { AccessKey: !Ref 'S3UserKeys', SecretAccessKey: !GetAtt [ S3UserKeys, SecretAccessKey ] }
+
 Outputs:
   InstanceId:
     Description: InstanceId of the newly created EC2 instance

--- a/jmeter-icap/cloudformation/AWS-Performance-Dashboard-and-S3-Bucket.yaml
+++ b/jmeter-icap/cloudformation/AWS-Performance-Dashboard-and-S3-Bucket.yaml
@@ -278,8 +278,8 @@ Resources:
       Name: "LoadGeneratorIamUserCredentials"
       SecretString:
         !Sub
-        - '{"AWS_Access_Key":"${AccessKey}","AWS_Secret_Key ":"${SecretAccessKey}"}'
-        - { AccessKey: !Ref 'S3UserKeys', SecretAccessKey: !GetAtt [ S3UserKeys, SecretAccessKey ] }
+        - '{"AWS_Access_Key": "${AccessKey}","AWS_Secret_Key ": "${SecretAccessKey}"}'
+        - {AccessKey: !Ref 'S3UserKeys', SecretAccessKey: !GetAtt [S3UserKeys, SecretAccessKey]}
 
 Outputs:
   InstanceId:


### PR DESCRIPTION
- Added Secrets Manager access key creation to AWS-Performance-Dashboard-and-S3-Bucket.yaml template. It creates a secret entry with two rows:
"AWS_Access_Key": ${generated user key}
"AWS_Secret_Key ": ${generated secret key}