### PR TITLE
Adding confirmation popover in setup UI's submit configurations button

### DIFF
--- a/UI Scaled Solution/master-script-form/src/app/setup-form/setup-form.component.html
+++ b/UI Scaled Solution/master-script-form/src/app/setup-form/setup-form.component.html
@@ -64,7 +64,11 @@
         <small class="form-text text-muted">Client Secret value (for use with SharePoint)</small>
     </div>
 
-    <button id="submit" type="submit" class="btn btn-primary" [disabled]="!isValid"> {{ submitButtonText }} </button>
+    <button id="submit" type="button" class="btn btn-primary" [disabled]="!isValid" mwlConfirmationPopover 
+    [popoverTitle]="popoverTitle" [popoverMessage]="popoverMessage" placement="right"
+    (confirm)="onSubmit()" type="button">
+         {{ submitButtonText }} 
+    </button>
 
     <div [@animationState]="animState" class="alert {{alertClass}}" role="alert" style="opacity: 0; display:inline-block;"
         type="text">

--- a/UI Scaled Solution/master-script-form/src/app/setup-form/setup-form.component.ts
+++ b/UI Scaled Solution/master-script-form/src/app/setup-form/setup-form.component.ts
@@ -33,6 +33,8 @@ export class SetupFormComponent implements OnInit {
   alertClass = "";
   alertText = "";
   submitButtonText = "Submit Configurations";
+  public popoverTitle: string = "Please Confirm";
+  public popoverMessage: string = "The configurations input above will overwrite previous configurations.";
   
   constructor(private fb: FormBuilder, private readonly http: HttpClient, private titleService: Title, private sharedService: SharedService) { }
 


### PR DESCRIPTION
- When the "Submit Configurations" button in the setup UI is pressed, a confirmation popover appears asking users to confirm. It states "The configurations input above will overwrite previous configurations." with choices to either confirm or cancel.