### PR TITLE
Updating ui_tasks.py: Modified "proxy" load type reference in back end

### DIFF
--- a/jmeter-icap/scripts/ui_tasks.py
+++ b/jmeter-icap/scripts/ui_tasks.py
@@ -107,6 +107,6 @@ def determine_tls_and_port_params(config, input_enable_tls, input_tls_ignore_ver
 
 class LoadType(str, Enum):
     direct = "Direct"
-    proxy = "Proxy Offline"
+    proxy = "Proxy"
     proxy_sharepoint = "Proxy SharePoint"
     direct_sharepoint = "Direct Sharepoint"


### PR DESCRIPTION
- The Proxy load type will be called "Proxy" in back end to preserve backwards compatibility with OVA.